### PR TITLE
Update to use correct template parameters

### DIFF
--- a/bmbfmod.json
+++ b/bmbfmod.json
@@ -20,6 +20,11 @@
             "uninstallAction": {
                 "removeLibraryFile": "lib{{ mod.out }}.so"
             }
+        },
+        {
+            "type": "FileCopyMod",
+            "sourceFileName": "libbeatsaber-hook_2019_2_1f1_0_2_0.so",
+            "targetRootedPathAndFileName": "/sdcard/Android/data/com.beatgames.beatsaber/files/libs/libbeatsaber-hook_2019_1_1f1_0_2_0.so"
         }
     ]
 }

--- a/buildBMBF.ps1
+++ b/buildBMBF.ps1
@@ -7,4 +7,4 @@ if (-not ($PSVersionTable.PSEdition -eq "Core")) {
 }
 
 & $buildScript NDK_PROJECT_PATH=$PSScriptRoot APP_BUILD_SCRIPT=$PSScriptRoot/Android.mk NDK_APPLICATION_MK=$PSScriptRoot/Application.mk
-Compress-Archive -Path "./libs/arm64-v8a/lib{{ mod.out }}.so","./bmbfmod.json" -DestinationPath "./{{ mod.out }}_v0.1.0.zip"
+Compress-Archive -Path "./libs/arm64-v8a/lib{{ mod.out }}.so","./bmbfmod.json","./include/libs/libbeatsaber-hook_2019_2_1f1_0_2_0.so" -DestinationPath "./{{ mod.out }}_v0.1.0.zip"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -116,7 +116,7 @@ __attribute__((constructor)) void lib_main() {
 extern "C" void setup(ModInfo& info) {
     // Set the ID and version of this mod
     info.id = "{{ mod.id }}";
-    info.version = "{{ mod.version }}";
+    info.version = "0.1.0";
     modInfo = info;
     // Log some information
     getLogger().info("Modloader name: %s", Modloader::getInfo().name.c_str());


### PR DESCRIPTION
`version` doesn't exist as a replaceable field, among other things being slightly incorrect what with BMBF builds